### PR TITLE
Handle the case when nav section is missing in mkdocs.yml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mkdocs-with-confluence",
-    version="0.2.2",
+    version="0.2.5",
     description="MkDocs plugin for uploading markdown documentation to Confluence via Confluence REST API",
     keywords="mkdocs markdown confluence documentation rest python",
     url="https://github.com/pawelsikora/mkdocs-with-confluence/",


### PR DESCRIPTION
Add handling of missing (may be on purpose)
navigation section (nav) in mkdocs.yml config file.

If pages are missing in nav, plugin will create the
required pages from the filesystem structure, e.g.

parent1/parent2/.../your_page.md:
# My Page
...

In the following manner:
Confluence Space:

    Main Parent:
        Parent1:
            Parent2:
            ...:
                My Page

Fixes #2