### PR TITLE
Image upload only when changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mkdocs_with_confluence/__pycache__/*
+mkdocs_with_confluence.egg-info/*

--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -218,7 +218,7 @@ class MkdocsWithConfluence(BasePlugin):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append(match.group(1))
-                    for match in re.finditer(r'!\[\w*\]\((.*)\)', markdown):
+                    for match in re.finditer(r"!\[\w*\]\((.*)\)", markdown):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append("docs/" + match.group(1))

--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -410,7 +410,7 @@ class MkdocsWithConfluence(BasePlugin):
                 existing_match = file_hash_regex.search(attachement["version"]["message"])
                 if existing_match is not None and existing_match.group(1) == file_hash:
                     if self.config["debug"]:
-                        print(f" * Mkdocs With Confluence * {page_name} *Existing attachment skipping * {filepath}")
+                        print(f" * Mkdocs With Confluence * {page_name} * Existing attachment skipping * {filepath}")
                 else:
                     self.update_attachment(page_id, filepath, attachement, attachement_message)
             else:

--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -1,5 +1,6 @@
 import time
 import os
+import hashlib
 import sys
 import re
 import tempfile
@@ -344,7 +345,7 @@ class MkdocsWithConfluence(BasePlugin):
                     n_kol = len("  *NEW ATTACHMENTS({len(attachments)})*")
                     print(f"\033[A\033[F\033[{n_kol}G  *NEW ATTACHMENTS({len(attachments)})*")
                     for f in attachments:
-                        self.add_attachment(page.title, f)
+                        self.add_or_update_attachment(page.title, f)
 
             except IndexError as e:
                 if self.config["debug"]:
@@ -387,36 +388,106 @@ class MkdocsWithConfluence(BasePlugin):
             print(f"WRN    - Page '{name}' doesn't exist in the mkdocs.yml nav section!")
             return name
 
-    def add_attachment(self, page_name, filepath):
-        print(f"INFO    - Mkdocs With Confluence * {page_name} *NEW ATTACHMENT* {filepath}")
+    # Adapted from https://stackoverflow.com/a/3431838
+    def get_file_sha1(self, file_path):
+        hash_sha1 = hashlib.sha1()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_sha1.update(chunk)
+        return hash_sha1.hexdigest()
+
+    def add_or_update_attachment(self, page_name, filepath):
+        print(f"INFO    - Mkdocs With Confluence * {page_name} *ADD/Update ATTACHMENT if required* {filepath}")
         if self.config["debug"]:
             print(f" * Mkdocs With Confluence: Add Attachment: PAGE NAME: {page_name}, FILE: {filepath}")
         page_id = self.find_page_id(page_name)
         if page_id:
-            url = self.config["host_url"] + "/" + page_id + "/child/attachment/"
-            headers = {"X-Atlassian-Token": "no-check"}  # no content-type here!
-            if self.config["debug"]:
-                print(f"URL: {url}")
-            filename = filepath
-            auth = (self.user, self.pw)
-
-            # determine content-type
-            content_type, encoding = mimetypes.guess_type(filename)
-            if content_type is None:
-                content_type = "multipart/form-data"
-            files = {"file": (filename, open(filename, "rb"), content_type), "comment": "File uploaded from MkdocsWithConfluence"}
-
-            if not self.dryrun:
-                r = requests.post(url, headers=headers, files=files, auth=auth)
-                print(r.json())
-                r.raise_for_status()
-                if r.status_code == 200:
-                    print("OK!")
+            file_hash = self.get_file_sha1(filepath)
+            attachement_message = f"MKDocsWithConfluence [v{file_hash}]"
+            attachement = self.get_attachment(page_id, filepath)
+            if attachement:
+                file_hash_regex = re.compile(r"\[v([a-f0-9]{40})]$")
+                existing_match = file_hash_regex.search(attachement["version"]["message"])
+                if existing_match is not None and existing_match.group(1) == file_hash:
+                    if self.config["debug"]:
+                        print(f" * Mkdocs With Confluence * {page_name} *Existing attachment skipping * {filepath}")
                 else:
-                    print("ERR!")
+                    self.update_attachment(page_id, filepath, attachement, attachement_message)
+            else:
+                self.create_attachment(page_id, filepath, attachement_message)
         else:
             if self.config["debug"]:
                 print("PAGE DOES NOT EXISTS")
+
+    def get_attachment(self, page_id, filepath):
+        name = os.path.basename(filepath)
+        if self.config["debug"]:
+            print(f" * Mkdocs With Confluence: Get Attachment: PAGE ID: {page_id}, FILE: {filepath}")
+
+        url = self.config["host_url"] + "/" + page_id + "/child/attachment"
+        headers = {"X-Atlassian-Token": "no-check"}  # no content-type here!
+        if self.config["debug"]:
+            print(f"URL: {url}")
+        auth = (self.user, self.pw)
+
+        r = requests.get(url, headers=headers, params={"filename": name, "expand": "version"}, auth=auth)
+        r.raise_for_status()
+        with nostdout():
+            response_json = r.json()
+        if response_json["size"]:
+            return response_json["results"][0]
+
+    def update_attachment(self, page_id, filepath, existing_attachment, message):
+        if self.config["debug"]:
+            print(f" * Mkdocs With Confluence: Update Attachment: PAGE ID: {page_id}, FILE: {filepath}")
+
+        url = self.config["host_url"] + "/" + page_id + "/child/attachment/" + existing_attachment["id"] + "/data"
+        headers = {"X-Atlassian-Token": "no-check"}  # no content-type here!
+        if self.config["debug"]:
+            print(f"URL: {url}")
+        filename = filepath
+        auth = (self.user, self.pw)
+
+        # determine content-type
+        content_type, encoding = mimetypes.guess_type(filename)
+        if content_type is None:
+            content_type = "multipart/form-data"
+        files = {"file": (filename, open(filename, "rb"), content_type), "comment": message}
+
+        if not self.dryrun:
+            r = requests.post(url, headers=headers, files=files, auth=auth)
+            r.raise_for_status()
+            print(r.json())
+            if r.status_code == 200:
+                print("OK!")
+            else:
+                print("ERR!")
+
+    def create_attachment(self, page_id, filepath, message):
+        if self.config["debug"]:
+            print(f" * Mkdocs With Confluence: Create Attachment: PAGE ID: {page_id}, FILE: {filepath}")
+
+        url = self.config["host_url"] + "/" + page_id + "/child/attachment"
+        headers = {"X-Atlassian-Token": "no-check"}  # no content-type here!
+        if self.config["debug"]:
+            print(f"URL: {url}")
+        filename = filepath
+        auth = (self.user, self.pw)
+
+        # determine content-type
+        content_type, encoding = mimetypes.guess_type(filename)
+        if content_type is None:
+            content_type = "multipart/form-data"
+        files = {"file": (filename, open(filename, "rb"), content_type), "comment": message}
+
+        if not self.dryrun:
+            r = requests.post(url, headers=headers, files=files, auth=auth)
+            print(r.json())
+            r.raise_for_status()
+            if r.status_code == 200:
+                print("OK!")
+            else:
+                print("ERR!")
 
     def find_page_id(self, page_name):
         if self.config["debug"]:

--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -218,7 +218,7 @@ class MkdocsWithConfluence(BasePlugin):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append(match.group(1))
-                    for match in re.finditer(r"!\[\w*\]\((.*)\)", markdown):
+                    for match in re.finditer(r"!\[[\w\. ]*\]\((?!http|file)(.*)\))", markdown):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append("docs/" + match.group(1))
@@ -403,18 +403,18 @@ class MkdocsWithConfluence(BasePlugin):
         page_id = self.find_page_id(page_name)
         if page_id:
             file_hash = self.get_file_sha1(filepath)
-            attachement_message = f"MKDocsWithConfluence [v{file_hash}]"
-            attachement = self.get_attachment(page_id, filepath)
-            if attachement:
+            attachment_message = f"MKDocsWithConfluence [v{file_hash}]"
+            existing_attachment = self.get_attachment(page_id, filepath)
+            if existing_attachment:
                 file_hash_regex = re.compile(r"\[v([a-f0-9]{40})]$")
-                existing_match = file_hash_regex.search(attachement["version"]["message"])
+                existing_match = file_hash_regex.search(existing_attachment["version"]["message"])
                 if existing_match is not None and existing_match.group(1) == file_hash:
                     if self.config["debug"]:
                         print(f" * Mkdocs With Confluence * {page_name} * Existing attachment skipping * {filepath}")
                 else:
-                    self.update_attachment(page_id, filepath, attachement, attachement_message)
+                    self.update_attachment(page_id, filepath, existing_attachment, attachment_message)
             else:
-                self.create_attachment(page_id, filepath, attachement_message)
+                self.create_attachment(page_id, filepath, attachment_message)
         else:
             if self.config["debug"]:
                 print("PAGE DOES NOT EXISTS")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mkdocs-with-confluence",
-    version="0.2.5",
+    version="0.2.6",
     description="MkDocs plugin for uploading markdown documentation to Confluence via Confluence REST API",
     keywords="mkdocs markdown confluence documentation rest python",
     url="https://github.com/pawelsikora/mkdocs-with-confluence/",


### PR DESCRIPTION
Changes to improve image uploading.
- Only upload images that have changed by recording a file hash as the image comment
- Add image to attachments based markdown formatted image links