### PR TITLE
Allow dash in attachment filename

### DIFF
--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -218,7 +218,7 @@ class MkdocsWithConfluence(BasePlugin):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append(match.group(1))
-                    for match in re.finditer(r"!\[[\w\. ]*\]\((?!http|file)(.*)\)", markdown):
+                    for match in re.finditer(r"!\[[\w\. -]*\]\((?!http|file)(.*)\)", markdown):
                         if self.config["debug"]:
                             print(f"DEBUG    - FOUND IMAGE: {match.group(1)}")
                         attachments.append("docs/" + match.group(1))


### PR DESCRIPTION
In addition to my regex from #10 I would like to add a hyphen, so image filename can include this character like `foo-bar.png`.

Signed-off-by: Simon Stamm <simon.stamm@tui.com>