### PR TITLE
Newlines and links

### DIFF
--- a/mkdocs_with_confluence/plugin.py
+++ b/mkdocs_with_confluence/plugin.py
@@ -17,7 +17,7 @@ from os import environ
 from pathlib import Path
 
 TEMPLATE_BODY = "<p> TEMPLATE </p>"
-
+PARENT_ID_RETRIES = 20
 
 @contextlib.contextmanager
 def nostdout():
@@ -287,6 +287,7 @@ class MkdocsWithConfluence(BasePlugin):
                         f"DEBUG    - BODY: {confluence_body}\n"
                     )
 
+                print(f"INFO - BUILDING PARENT: {parent}")
                 page_id = self.find_page_id(page.title)
                 if page_id is not None:
                     if self.config["debug"]:
@@ -350,20 +351,16 @@ class MkdocsWithConfluence(BasePlugin):
                                 print(f"INFO    - Mkdocs With Confluence: {i} *NEW PAGE*")
                         time.sleep(1)
 
-                    if parent_id is None:
-                        for i in range(11):
-                            while parent_id is None:
-                                try:
-                                    self.add_page(page.title, parent_id, confluence_body)
-                                except requests.exceptions.HTTPError:
-                                    print(
-                                        f"ERR    - HTTP error on adding page. It probably occured due to "
-                                        f"parent ID('{parent_id}') page is not YET synced on server. Retry nb {i}/10..."
-                                    )
-                                    sleep(5)
-                                    parent_id = self.find_page_id(parent)
-                                break
-
+                    retries = PARENT_ID_RETRIES
+                    while parent_id is None:
+                        if retries <= 0:
+                            print(f"ERR: Can't find the right parent_id for {parent}", file=sys.stderr)
+                            sys.exit(1)
+                        print(f"INFO    - let's try find {parent} again", file=sys.stderr)
+                        parent_id = self.find_page_id(parent)
+                        sleep(5)
+                        retries -= 1
+                    print(f"INFO    - We found {parent}'s id! {parent_id}", file=sys.stderr)
                     self.add_page(page.title, parent_id, confluence_body)
 
                     print(f"Trying to ADD page '{page.title}' to parent0({parent}) ID: {parent_id}")


### PR DESCRIPTION
This PR will enable the `remove_text_newlines=True` flag for the markdown renderer, removing the extra newlines in paragraphs on confluence. The markdown standard ignores newlines in paragraphs (as HTML does) but Confluence renders them anyway.

It also adds the ability to link to other documents like [mkdocs supports](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages). It does, however, tightly couple the older version of mistune that md2cf uses.